### PR TITLE
fix artifactory-installer

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ArtifactoryInstaller.java
@@ -29,10 +29,14 @@ public class ArtifactoryInstaller extends BinaryInstaller {
     public final String repository;
 
     @DataBoundConstructor
-    public ArtifactoryInstaller(String id, String repository) {
-        super(null);
+    public ArtifactoryInstaller(String id, String repository, String version) {
+        super(null,version);
         this.serverId = id;
         this.repository = repository;
+    }
+
+    public ArtifactoryInstaller(String id, String repository) {
+        this(id, repository, "");
     }
 
     @Override
@@ -42,7 +46,7 @@ public class ArtifactoryInstaller extends BinaryInstaller {
             throw new IOException("Server id '" + serverId + "' doesn't exists.");
         }
         String binaryName = Utils.getJfrogCliBinaryName(!node.createLauncher(log).isUnix());
-        return performJfrogCliInstallation(getToolLocation(tool, node), log, StringUtils.EMPTY, server, repository, binaryName);
+        return performJfrogCliInstallation(getToolLocation(tool, node), log, getVersion(), server, repository, binaryName);
     }
 
     /**
@@ -50,14 +54,14 @@ public class ArtifactoryInstaller extends BinaryInstaller {
      */
     private JFrogPlatformInstance getSpecificServer(String id) {
         List<JFrogPlatformInstance> jfrogInstances = JFrogPlatformBuilder.getJFrogPlatformInstances();
-        if (jfrogInstances != null && jfrogInstances.size() > 0) {
+        if (jfrogInstances != null && !jfrogInstances.isEmpty()) {
             for (JFrogPlatformInstance jfrogPlatformInstance : jfrogInstances) {
                 if (jfrogPlatformInstance.getId().equals(id)) {
                     // Getting credentials
                     // We sent a null item to 'credentialsLookup' since we do not know which job will be running at the time of installation, and we don't have the relevant 'Run' object yet.
                     // Therefore, when downloading the CLI from the user's Artifactory remote repository, we should use global credentials.
-                    Credentials credentials = PluginsUtils.credentialsLookup(id, null);
-                    jfrogPlatformInstance.setCredentialsConfig(new CredentialsConfig(id, credentials));
+                    Credentials credentials = PluginsUtils.credentialsLookup( jfrogPlatformInstance.getCredentialsConfig().getCredentialsId(), null);
+                    jfrogPlatformInstance.setCredentialsConfig(new CredentialsConfig(jfrogPlatformInstance.getCredentialsConfig().getCredentialsId(), credentials));
                     return jfrogPlatformInstance;
                 }
             }

--- a/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/BinaryInstaller.java
@@ -34,6 +34,9 @@ public abstract class BinaryInstaller extends ToolInstaller {
      */
     private static final String RELEASE = "[RELEASE]";
 
+
+
+    private final String version;
     /**
      * The name of the file that contains the JFrog CLI binary sha256.
      * The file will help us determine if we should download an updated version or skip it.
@@ -41,7 +44,12 @@ public abstract class BinaryInstaller extends ToolInstaller {
     private static final String SHA256_FILE_NAME = "sha256";
 
     protected BinaryInstaller(String label) {
+        this(label, RELEASE);
+    }
+
+    protected BinaryInstaller(String label, String version) {
         super(label);
+        this.version=version;
     }
 
     /**
@@ -162,6 +170,10 @@ public abstract class BinaryInstaller extends ToolInstaller {
             }
         });
         return toolLocation;
+    }
+
+    public String getVersion() {
+        return version;
     }
 }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/JfrogInstallation.java
@@ -37,8 +37,9 @@ public class JfrogInstallation extends ToolInstallation
     public static final String JFROG_CLI_USER_AGENT = "JFROG_CLI_USER_AGENT";
     public static final String JfrogDependenciesDirName = "dependencies";
 
+
     @DataBoundConstructor
-    public JfrogInstallation(String name, String home, List<? extends ToolProperty<?>> properties) {
+    public JfrogInstallation(String name, String home, List<? extends ToolProperty<?>> properties ){
         super(name, home, properties);
     }
 

--- a/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/ReleasesInstaller.java
@@ -20,21 +20,19 @@ import java.io.IOException;
  * @author gail
  */
 public class ReleasesInstaller extends BinaryInstaller {
-    public final String id;
     public static final String RELEASES_ARTIFACTORY_URL = "https://releases.jfrog.io/artifactory";
     public static final String REPOSITORY = "jfrog-cli";
 
     @DataBoundConstructor
     public ReleasesInstaller(String id) {
-        super(null);
-        this.id = id;
+        super(null, id);
     }
 
     @Override
     public FilePath performInstallation(ToolInstallation tool, Node node, TaskListener log) throws IOException, InterruptedException {
         JFrogPlatformInstance instance = createReleasesPlatformInstance();
         String binaryName = Utils.getJfrogCliBinaryName(!node.createLauncher(log).isUnix());
-        return performJfrogCliInstallation(getToolLocation(tool, node), log, id, instance, REPOSITORY, binaryName);
+        return performJfrogCliInstallation(getToolLocation(tool, node), log, getVersion(), instance, REPOSITORY, binaryName);
     }
 
     /**

--- a/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/jfrog/ArtifactoryInstaller/config.jelly
@@ -9,5 +9,9 @@
         <f:entry title="${%Remote JFrog CLI repository}" field="repository">
             <f:textbox/>
         </f:entry>
+        <f:entry title="${%Version}" field="version">
+            <f:entry title="(Leave empty to get the latest version)"/>
+            <f:textbox/>
+        </f:entry>
     </f:entry>
 </j:jelly>


### PR DESCRIPTION
use credentialID instead of serverId to get credentials from jenkins. Configure version via manage tools

- [ ] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
