### PR TITLE
On MacOSX, os.arch=aarch64 should use arm64 variant of jf

### DIFF
--- a/src/main/java/io/jenkins/plugins/jfrog/OsUtils.java
+++ b/src/main/java/io/jenkins/plugins/jfrog/OsUtils.java
@@ -17,7 +17,7 @@ public class OsUtils {
         }
         // Mac
         if (SystemUtils.IS_OS_MAC) {
-            if (OS_ARCH.contains("arm64")) {
+            if (OS_ARCH.contains("arm64") || OS_ARCH.contains("aarch64")) {
                 return "mac-arm64";
             }
             return "mac-386";


### PR DESCRIPTION
Closes issue #17

- [ ] This pull request is created in the [jfrog/jenkins-jfrog-plugin](https://github.com/jfrog/jenkins-jfrog-plugin) repository.
